### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,20 @@
 from setuptools import setup, find_packages
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name='mkdocs-add-number-plugin',
     version='1.1.0',
     description='A MkDocs plugin to add number to titles of page.',
-    long_description='A MkDocs plugin to add number to titles of page.<br>'
-                     '[options]:<br>'
-                     'strict_mode: True|False<br>'
-                     'order: number<br>'
-                     'excludes: list|"*"<br>'
-                     'includes: list<br><br>'
-                     'For detailed usage, please refer to `Homepage`',
-    long_description_content_type='text/markdown',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     keywords='mkdocs index add-number plugin',
     url='https://github.com/shihr/mkdocs-add-number-plugin.git',
     author='shihr',
     author_email='shrshraa@outlook.com',
     license='MIT',
-    python_requires='>=2.7',
+    python_requires='>=3.5',
     install_requires=[
         'mkdocs>=1.0.4'
     ],


### PR DESCRIPTION
Two proposed changes:

- Add the `README.md` as `long_description`. This will insert your README as the description on PyPi.
- MkDocs has dropped support for python 2, and now requires python 3.5+.